### PR TITLE
Fix tmux navigation key and remove duplicate TPM initialization

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -29,7 +29,7 @@ bind-key v split-window -h
 bind-key g split-window -v
 
 bind-key h select-pane -L
-bind-key j select-pane -
+bind-key j select-pane -D
 bind-key k select-pane -U
 bind-key l select-pane -R
 
@@ -82,9 +82,6 @@ set -ga status-right "#[bg=default,fg=#{@thm_blue}] 󰭦 %Y-%m-%d 󰅐 %H:%M "
 # bootstrap tpm
 if "test ! -d ~/.tmux/plugins/tpm" \
    "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
-
-# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
-run '~/.tmux/plugins/tpm/tpm'
 
 # Configure Tmux
 set -g status-position top


### PR DESCRIPTION
## Summary
- correct pane navigation keybinding in `.tmux.conf`
- keep single TPM plugin manager initialization

## Testing
- `sh -n tmux/utils/create_win_run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68412bd309748330ab4b8669da865795